### PR TITLE
Fix blank transition type

### DIFF
--- a/src/blank.rs
+++ b/src/blank.rs
@@ -15,14 +15,13 @@ use bitcoin::OutPoint;
 use bp::seals::txout::CloseMethod;
 use rgb_core::bundle::NoDataError;
 use rgb_core::schema::OwnedRightType;
+use rgb_core::vm::embedded::constants::TRANSITION_TYPE_VALUE_TRANSFER;
 use rgb_core::{
     seal, NodeId, NodeOutpoint, OwnedRights, ParentOwnedRights, Transition, TransitionBundle,
     TypedAssignments,
 };
 
 use crate::state::OutpointState;
-
-pub const BLANK_TRANSITION_TYPE: u16 = 0x8000;
 
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display, Error, From)]
 #[display(doc_comments)]
@@ -75,7 +74,7 @@ impl BlankBundle for TransitionBundle {
                 owned_rights.insert(input.ty, new_assignments);
             }
             let transition = Transition::with(
-                BLANK_TRANSITION_TYPE,
+                TRANSITION_TYPE_VALUE_TRANSFER,
                 empty!(),
                 empty!(),
                 OwnedRights::from(owned_rights),


### PR DESCRIPTION
While testing RGB with a [draft RGB21 schema](https://github.com/RGB-Tools/rust-rgb21/blob/change_schema/src/schema.rs) we discovered a bug with blank transitions that does not happen on RGB20 (only for a coincidence).

In the `blank` rgb-std method the constructed `Transition` gets assigned with a `BLANK_TRANSITION_TYPE` transition type. This constant (value `0x8000`) is defined in the same file of the method but is not imported in any other RGB project.

Since the hunted bug was that blank transitions (only of RGB21 contracts) weren't used as RGB "inputs" in the consignment created with the `consign` rgb-node API, I started debugging that. Inspecting the consignment construction code I've noticed that `CONTRACT_TRANSITIONS` is retrieved by looping on the schema transition keys:

```rust
for transition_type in schema.transitions.keys() {
    let chunk_id = ChunkId::with_fixed_fragments(contract_id, *transition_type);
    let node_ids: BTreeSet<NodeId> =
        self.store.retrieve_sten(db::CONTRACT_TRANSITIONS, chunk_id)?.unwrap_or_default();
    let filter = if always_include.contains(transition_type) {
        &outpoints_all
    } else {
        &outpoint_filter
    };
    collector.process(&mut self.store, node_ids, filter)?;
}
```

These keys are defined at a schema-level, you can find the ones used for RGB20 [here](https://github.com/RGB-WG/rust-rgb20/blob/master/src/schema.rs#L113).

Looking at those `TransitionType` values I've noticed `RightsSplit = TRANSITION_TYPE_RIGHTS_SPLIT`. `TRANSITION_TYPE_RIGHTS_SPLIT` [comes from rgb-core](https://github.com/RGB-WG/rgb-core/blob/master/src/vm/embedded.rs#L147) and has value `0x8000`, the same of `BLANK_TRANSITION_TYPE`.

To prove the bug was there I just changed the value of the `BLANK_TRANSITION_TYPE` to `0x8002` (any number outside RGB20 `TransitionType` values should do the trick) and all tests on RGB20 blank transitions stop working.

I believe that `BLANK_TRANSITION_TYPE` and `TRANSITION_TYPE_RIGHTS_SPLIT` having the same value is just a coincidence and we need a proper fix.

Currently I've fixed the issue by changing `BLANK_TRANSITION_TYPE` with a `TRANSITION_TYPE_VALUE_TRANSFER`. Not sure this is the desired fix since I can see some other solutions, but this seems the "correct" one to me.
