### PR TITLE
RgbInvoice: make contract optional

### DIFF
--- a/src/invoice.rs
+++ b/src/invoice.rs
@@ -170,12 +170,10 @@ impl FromStr for RgbInvoice {
                 next_path_index += 1;
                 Some(cid)
             }
-            Err(_e) => {
-                if !uri.path().to_string().starts_with('/') {
-                    return Err(InvoiceParseError::InvalidContractId(contract_id_str.clone()));
-                }
-                None
+            Err(_) if !uri.path().as_str().starts_with('/') =>  {
+                return Err(InvoiceParseError::InvalidContractId(contract_id_str.clone()));
             }
+            Err(_) => None,
         };
 
         let iface = TypeName::try_from(path[next_path_index].clone())?;

--- a/src/invoice.rs
+++ b/src/invoice.rs
@@ -170,7 +170,7 @@ impl FromStr for RgbInvoice {
                 next_path_index += 1;
                 Some(cid)
             }
-            Err(_) if !uri.path().as_str().starts_with('/') =>  {
+            Err(_) if !uri.path().as_str().starts_with('/') => {
                 return Err(InvoiceParseError::InvalidContractId(contract_id_str.clone()));
             }
             Err(_) => None,

--- a/src/pay.rs
+++ b/src/pay.rs
@@ -50,6 +50,10 @@ where E1: From<E2>
     #[display(doc_comments)]
     NoBeneficiaryOutput,
 
+    /// unspecified contract
+    #[display(doc_comments)]
+    NoContract,
+
     /// state provided via PSBT inputs is not sufficient to cover invoice state
     /// requirements.
     InsufficientState,
@@ -85,7 +89,7 @@ pub trait InventoryWallet: Inventory {
         Self::Error: From<<Self::Stash as Stash>::Error>,
     {
         // 1. Prepare the data
-        let contract_id = invoice.contract;
+        let contract_id = invoice.contract.ok_or(PayError::NoContract)?;
         let mut main_builder = self.transition_builder(contract_id, invoice.iface.clone())?;
 
         let (beneficiary_output, beneficiary) = match invoice.beneficiary {


### PR DESCRIPTION
This PR makes the `contract` field of the `RgbInvoice` struct optional.
As discussed in a previous call this allows use cases where a user wants to receive an asset but doesn't care about which asset (e.g. collectibles donation).