### PR TITLE
Fix dbc_conclude commitment host count

### DIFF
--- a/src/psbt/dbc.rs
+++ b/src/psbt/dbc.rs
@@ -92,7 +92,7 @@ impl PsbtDbc for Psbt {
         if self
             .outputs
             .iter()
-            .map(|output| output.is_tapret_host() | output.is_opret_host())
+            .filter(|output| output.is_tapret_host() | output.is_opret_host())
             .count() >
             1
         {


### PR DESCRIPTION
This small PR fixes the count of output commitment hosts in `dbc_conclude`.

It counted all outputs, now only counts ones containing commitment hosts, as intended.