### PR TITLE
make iface optional and add expiry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,6 +791,7 @@ dependencies = [
  "rgb-core",
  "rgb-std",
  "strict_encoding",
+ "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]
@@ -1177,6 +1178,12 @@ name = "unsafe-libyaml"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+
+[[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,9 +311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
+ "time 0.1.45",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -501,7 +504,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -779,6 +782,7 @@ dependencies = [
  "baid58",
  "bitcoin",
  "bp-core",
+ "chrono",
  "commit_verify",
  "fluent-uri",
  "getrandom",
@@ -935,7 +939,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -1071,6 +1075,17 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
@@ -1168,6 +1183,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ indexmap = "1.9.2"
 # TODO: This dependencies should be replaced with psbt package
 bitcoin = "0.30.0"
 chrono = "0.4.24"
+urlencoding = "2.1.2"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ fluent-uri = "0.1.4"
 indexmap = "1.9.2"
 # TODO: This dependencies should be replaced with psbt package
 bitcoin = "0.30.0"
+chrono = "0.4.24"
 
 [features]
 default = []

--- a/src/pay.rs
+++ b/src/pay.rs
@@ -54,6 +54,10 @@ where E1: From<E2>
     #[display(doc_comments)]
     NoContract,
 
+    /// unspecified interface
+    #[display(doc_comments)]
+    NoIface,
+
     /// state provided via PSBT inputs is not sufficient to cover invoice state
     /// requirements.
     InsufficientState,
@@ -90,7 +94,8 @@ pub trait InventoryWallet: Inventory {
     {
         // 1. Prepare the data
         let contract_id = invoice.contract.ok_or(PayError::NoContract)?;
-        let mut main_builder = self.transition_builder(contract_id, invoice.iface.clone())?;
+        let iface = invoice.iface.ok_or(PayError::NoIface)?;
+        let mut main_builder = self.transition_builder(contract_id, iface.clone())?;
 
         let (beneficiary_output, beneficiary) = match invoice.beneficiary {
             Beneficiary::BlindedSeal(seal) => {
@@ -223,7 +228,7 @@ pub trait InventoryWallet: Inventory {
         let mut other_transitions = HashMap::with_capacity(spent_state.len());
         for (id, opouts) in spent_state {
             let mut blank_builder = self
-                .transition_builder(id, invoice.iface.clone())?
+                .transition_builder(id, iface.clone())?
                 .do_blank_transition()?;
             // TODO: select supplement basing on the signer trust level
             let suppl = self.contract_suppl(id).and_then(|set| set.first());


### PR DESCRIPTION
This PR changes `RgbInvoice`:
- using the `~` character to denote empty path prameters
- making the `iface` field optional
- adding the `expiry` field
- improving the handling of unknown query parameters

Note: the `~` character has been introduced because having both contract ID and iface optional broke url parsing when they were both missing.