### PR TITLE
add invoice transport parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,11 +793,11 @@ dependencies = [
  "fluent-uri",
  "getrandom",
  "indexmap",
+ "percent-encoding",
  "rand",
  "rgb-core",
  "rgb-std",
  "strict_encoding",
- "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]
@@ -1178,12 +1184,6 @@ name = "unsafe-libyaml"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
-
-[[package]]
-name = "urlencoding"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ indexmap = "1.9.2"
 # TODO: This dependencies should be replaced with psbt package
 bitcoin = "0.30.0"
 chrono = "0.4.24"
-urlencoding = "2.1.2"
+percent-encoding = "2.2.0"
 
 [features]
 default = []

--- a/src/invoice.rs
+++ b/src/invoice.rs
@@ -146,22 +146,22 @@ fn percent_decode(estr: &EStr) -> Result<String, InvoiceParseError> {
         .to_string())
 }
 
-impl RgbInvoice {
-    fn map_query_params(uri: &Uri<&str>) -> Result<IndexMap<String, String>, InvoiceParseError> {
-        let mut map: IndexMap<String, String> = IndexMap::new();
-        if let Some(q) = uri.query() {
-            let params = q.split('&');
-            for p in params {
-                if let Some((k, v)) = p.split_once('=') {
-                    map.insert(percent_decode(k)?, percent_decode(v)?);
-                } else {
-                    return Err(InvoiceParseError::InvalidQueryParam(p.to_string()));
-                }
+fn map_query_params(uri: &Uri<&str>) -> Result<IndexMap<String, String>, InvoiceParseError> {
+    let mut map: IndexMap<String, String> = IndexMap::new();
+    if let Some(q) = uri.query() {
+        let params = q.split('&');
+        for p in params {
+            if let Some((k, v)) = p.split_once('=') {
+                map.insert(percent_decode(k)?, percent_decode(v)?);
+            } else {
+                return Err(InvoiceParseError::InvalidQueryParam(p.to_string()));
             }
         }
-        Ok(map)
     }
+    Ok(map)
+}
 
+impl RgbInvoice {
     fn has_params(&self) -> bool { self.expiry.is_some() || !self.unknown_query.is_empty() }
 
     fn query_params(&self) -> IndexMap<String, String> {
@@ -276,7 +276,7 @@ impl FromStr for RgbInvoice {
                 }
             };
 
-        let mut query_params = RgbInvoice::map_query_params(&uri)?;
+        let mut query_params = map_query_params(&uri)?;
 
         let mut expiry = None;
         if let Some(exp) = query_params.remove(EXPIRY) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,9 @@ mod invoice;
 mod pay;
 pub mod psbt;
 
-pub use invoice::{Beneficiary, InvoiceParseError, InvoiceState, RgbInvoice, RgbTransport};
+pub use invoice::{
+    Beneficiary, InvoiceParseError, InvoiceState, RgbInvoice, RgbTransport, TransportParseError,
+};
 pub use pay::{InventoryWallet, PayError};
 
 // 1. Construct main state transition with transition builder


### PR DESCRIPTION
This PR adds parsing for the `RgbTransport` from the invoice's scheme.

The format for the transport I chose is `<transport><tls>-<host>`, where:
- `<transport>` is the transport name (with no `-` character, as it's used to separate the host portion)
- `<tls>` is `0` for cleartext and `1` is for tls
- `<host>` is the transport host (can contain `-` characters)

I (temporarily) commented RestHttp, WebSockets and Storm variants as they're now unused.

I also moved the `map_query_params` function out of `RgbInvoice` as it doesn't use self (as noted in a previous PR).

In the context of issue #34, I kept the tls parameter (to avoid breaking URL integrity) but used 0/1 for brevity and didn't use the `+` charachter, which I plan to use to support multiple transports (did a minimal test implementation and it appears to work as intended)