### PR TITLE
set opret/tapret host if needed

### DIFF
--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -29,9 +29,9 @@ mod lnpbp4;
 // TODO: Move to BP wallet
 mod dbc;
 // TODO: Move to BP wallet
-mod opret;
+pub mod opret;
 // TODO: Move to BP wallet
-mod tapret;
+pub mod tapret;
 mod rgb;
 
 pub use dbc::{DbcPsbtError, PsbtDbc};


### PR DESCRIPTION
This PR adds support for automatically setting opret/tapret host if needed.

The implementation is similar to my previous rgb-std PRs #14 and #15.

Note: I made the `opret` and `tapret` modules from `psbt` public (and not just `pub(crate)`) as they're also useful outside of rgb-wallet (e.g. we need to use `opret` in rgb-lib).