### PR TITLE
Fix use of velocity classes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,12 @@ pub use invoice::{
 };
 pub use pay::{InventoryWallet, PayError};
 
+/// BIP32 derivation index for outputs which may contain assigned RGB state.
+pub const RGB_NATIVE_DERIVATION_INDEX: u32 = 9;
+/// BIP32 derivation index for outputs which are tweaked with Tapret commitment
+/// and may also optionally contain assigned RGB state.
+pub const RGB_TAPRET_DERIVATION_INDEX: u32 = 10;
+
 // 1. Construct main state transition with transition builder
 // -- shortcut using invoice to do that construction (like .with_invoice())
 // -- have a construction for the "remaining state" assigned to a seal

--- a/src/pay.rs
+++ b/src/pay.rs
@@ -34,8 +34,8 @@ use rgbstd::interface::{BuilderError, ContractSuppl, TypedState, VelocityHint};
 use rgbstd::persistence::{ConsignerError, Inventory, InventoryError, Stash};
 
 use crate::invoice::Beneficiary;
-use crate::psbt::{DbcPsbtError, PsbtDbc, RgbExt, RgbInExt, RgbPsbtError};
-use crate::RgbInvoice;
+use crate::psbt::{DbcPsbtError, PsbtDbc, RgbExt, RgbInExt, RgbOutExt, RgbPsbtError};
+use crate::{RgbInvoice, RGB_NATIVE_DERIVATION_INDEX, RGB_TAPRET_DERIVATION_INDEX};
 
 #[derive(Debug, Display, Error, From)]
 #[display(inner)]
@@ -141,16 +141,17 @@ pub trait InventoryWallet: Inventory {
             if beneficiary_output == Some(no as u32) {
                 continue;
             }
-            if let Some(class) = outp
+            if outp
                 // NB: Here we assume that if output has derivation information it belongs to our wallet.
                 .bip32_derivation
                 .first_key_value()
                 .and_then(|(_, src)| src.1.into_iter().rev().nth(1))
                 .copied()
                 .map(u32::from)
-                .and_then(|index| u8::try_from(index).ok())
-                .and_then(|index| VelocityHint::try_from(index).ok())
+                .filter(|index| *index == RGB_NATIVE_DERIVATION_INDEX || *index == RGB_TAPRET_DERIVATION_INDEX)
+                .is_some()
             {
+                let class = outp.rgb_velocity_hint().unwrap_or_default();
                 out_classes.entry(class).or_default().push(no as u32);
             }
         }

--- a/src/pay.rs
+++ b/src/pay.rs
@@ -43,7 +43,7 @@ pub enum PayError<E1: Error, E2: Error>
 where E1: From<E2>
 {
     /// not enough PSBT output found to put all required state (can't add
-    /// assignment {1} for {0}-velocity state).
+    /// assignment type {1} for {0}-velocity state).
     #[display(doc_comments)]
     NoBlankOrChange(VelocityHint, AssignmentType),
 

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -49,6 +49,6 @@ pub use tapret::{
 };
 
 pub use self::rgb::{
-    ProprietaryKeyRgb, RgbExt, RgbInExt, RgbPsbtError, PSBT_GLOBAL_RGB_TRANSITION,
-    PSBT_IN_RGB_CONSUMED_BY, PSBT_RGB_PREFIX,
+    ProprietaryKeyRgb, RgbExt, RgbInExt, RgbOutExt, RgbPsbtError, PSBT_GLOBAL_RGB_TRANSITION,
+    PSBT_IN_RGB_CONSUMED_BY, PSBT_OUT_RGB_VELOCITY_HINT, PSBT_RGB_PREFIX,
 };

--- a/std/src/interface/suppl.rs
+++ b/std/src/interface/suppl.rs
@@ -124,4 +124,15 @@ pub enum VelocityHint {
     HighFrequency = 255,
 }
 
+impl VelocityHint {
+    pub fn with_value(value: &u8) -> Self {
+        match *value {
+            0 => VelocityHint::Unspecified,
+            1..=15 => VelocityHint::Seldom,
+            16..=31 => VelocityHint::Episodic,
+            32..=63 => VelocityHint::Regular,
+            64..=127 => VelocityHint::Frequent,
+            128..=255 => VelocityHint::HighFrequency,
+        }
+    }
 }

--- a/std/src/interface/suppl.rs
+++ b/std/src/interface/suppl.rs
@@ -113,13 +113,15 @@ pub enum VelocityHint {
     Unspecified = 0,
     /// Should be used for thinks like secondary issuance for tokens which do
     /// not inflate very often.
-    Seldom = 10,
+    Seldom = 15,
     /// Should be used for digital identity revocations.
-    Episodic = 25,
+    Episodic = 31,
     /// Should be used for digital art, shares, bonds etc.
-    Regular = 50,
+    Regular = 63,
     /// Should be used for fungible tokens.
-    Frequent = 75,
+    Frequent = 127,
     /// Should be used for stablecoins and money.
-    HighFrequency = 100,
+    HighFrequency = 255,
+}
+
 }


### PR DESCRIPTION
Closes #73

Please keep in mind that with this change if you'd like to use velocity classes you need to assign to your PSBT outputs a new proprietary key indicating the velocity class you are using.