### PR TITLE
Add blank state transitions to state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,7 +700,7 @@ dependencies = [
 [[package]]
 name = "rgb-core"
 version = "0.10.4"
-source = "git+https://github.com/RGB-WG/rgb-core#1de67f7bcd655bbb497074da50c0872cb1ae433a"
+source = "git+https://github.com/RGB-WG/rgb-core?branch=preserve-historic-state#23706b572aa4e6acf371b7dcb9c15b82e56c0dce"
 dependencies = [
  "aluvm",
  "amplify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,4 +78,4 @@ wasm-bindgen-test = "0.3"
 features = [ "all" ]
 
 [patch.crates-io]
-rgb-core = { git = "https://github.com/RGB-WG/rgb-core" }
+rgb-core = { git = "https://github.com/RGB-WG/rgb-core", branch = "preserve-historic-state" }

--- a/std/src/interface/builder.rs
+++ b/std/src/interface/builder.rs
@@ -357,7 +357,13 @@ impl<Seal: ExposedSeal> OperationBuilder<Seal> {
         let serialized = value.to_strict_serialized::<{ u16::MAX as usize }>()?;
 
         // Check value matches type requirements
-        let Some(type_id) = self.iimpl.global_state.iter().find(|t| t.name == name).map(|t| t.id) else {
+        let Some(type_id) = self
+            .iimpl
+            .global_state
+            .iter()
+            .find(|t| t.name == name)
+            .map(|t| t.id)
+        else {
             return Err(BuilderError::GlobalNotFound(name));
         };
         let sem_id = self
@@ -383,7 +389,13 @@ impl<Seal: ExposedSeal> OperationBuilder<Seal> {
     ) -> Result<Self, BuilderError> {
         let name = name.into();
 
-        let Some(type_id) = self.iimpl.assignments.iter().find(|t| t.name == name).map(|t| t.id) else {
+        let Some(type_id) = self
+            .iimpl
+            .assignments
+            .iter()
+            .find(|t| t.name == name)
+            .map(|t| t.id)
+        else {
             return Err(BuilderError::AssignmentNotFound(name));
         };
 
@@ -418,7 +430,13 @@ impl<Seal: ExposedSeal> OperationBuilder<Seal> {
         let name = name.into();
         let serialized = value.to_strict_serialized::<U16>()?;
 
-        let Some(type_id) = self.iimpl.assignments.iter().find(|t| t.name == name).map(|t| t.id) else {
+        let Some(type_id) = self
+            .iimpl
+            .assignments
+            .iter()
+            .find(|t| t.name == name)
+            .map(|t| t.id)
+        else {
             return Err(BuilderError::AssignmentNotFound(name));
         };
 

--- a/std/src/persistence/stock.rs
+++ b/std/src/persistence/stock.rs
@@ -29,11 +29,7 @@ use bp::dbc::Anchor;
 use bp::Txid;
 use commit_verify::mpc::MerkleBlock;
 use rgb::validation::{Status, Validity, Warning};
-use rgb::{
-    validation, AnchorId, AnchoredBundle, Assign, AssignmentType, BundleId, ContractHistory,
-    ContractId, ContractState, ExposedState, Extension, Genesis, GenesisSeal, GraphSeal, OpId,
-    Operation, Opout, SecretSeal, SubSchema, Transition, TransitionBundle, TxoSeal, TypedAssigns,
-};
+use rgb::{validation, AnchorId, AnchoredBundle, Assign, AssignmentType, BundleId, ContractHistory, ContractId, ContractState, ExposedState, Extension, Genesis, GenesisSeal, GraphSeal, OpId, Operation, Opout, SecretSeal, SubSchema, Transition, TransitionBundle, TxoSeal, TypedAssigns, OrderedTxid};
 use strict_encoding::{StrictDeserialize, StrictSerialize};
 
 use crate::containers::{Bindle, Cert, Consignment, ContentId, Contract, TerminalSeal, Transfer};
@@ -511,6 +507,13 @@ impl Inventory for Stock {
         witness_txid: Txid,
     ) -> Result<(), InventoryError<<Self as Inventory>::Error>> {
         self.index_bundle(contract_id, &bundle, witness_txid)?;
+        let history = self.history.get_mut(&contract_id).ok_or(InventoryInconsistency::StateAbsent(contract_id))?;
+        for item in bundle.values() {
+            if let Some(transition) = &item.transition {
+                let ord_txid = OrderedTxid::new(0, witness_txid);
+                history.add_transition(transition, ord_txid);
+            }
+        }
         self.hoard.consume_bundle(bundle)?;
         Ok(())
     }

--- a/std/src/persistence/stock.rs
+++ b/std/src/persistence/stock.rs
@@ -29,7 +29,12 @@ use bp::dbc::Anchor;
 use bp::Txid;
 use commit_verify::mpc::MerkleBlock;
 use rgb::validation::{Status, Validity, Warning};
-use rgb::{validation, AnchorId, AnchoredBundle, Assign, AssignmentType, BundleId, ContractHistory, ContractId, ContractState, ExposedState, Extension, Genesis, GenesisSeal, GraphSeal, OpId, Operation, Opout, SecretSeal, SubSchema, Transition, TransitionBundle, TxoSeal, TypedAssigns, OrderedTxid};
+use rgb::{
+    validation, AnchorId, AnchoredBundle, Assign, AssignmentType, BundleId, ContractHistory,
+    ContractId, ContractState, ExposedState, Extension, Genesis, GenesisSeal, GraphSeal, OpId,
+    Operation, Opout, OrderedTxid, SecretSeal, SubSchema, Transition, TransitionBundle, TxoSeal,
+    TypedAssigns,
+};
 use strict_encoding::{StrictDeserialize, StrictSerialize};
 
 use crate::containers::{Bindle, Cert, Consignment, ContentId, Contract, TerminalSeal, Transfer};
@@ -507,7 +512,10 @@ impl Inventory for Stock {
         witness_txid: Txid,
     ) -> Result<(), InventoryError<<Self as Inventory>::Error>> {
         self.index_bundle(contract_id, &bundle, witness_txid)?;
-        let history = self.history.get_mut(&contract_id).ok_or(InventoryInconsistency::StateAbsent(contract_id))?;
+        let history = self
+            .history
+            .get_mut(&contract_id)
+            .ok_or(InventoryInconsistency::StateAbsent(contract_id))?;
         for item in bundle.values() {
             if let Some(transition) = &item.transition {
                 let ord_txid = OrderedTxid::new(0, witness_txid);


### PR DESCRIPTION
Fixes #80

The bug was caused by the fact that we do state update only on consignment consumation - and not on production of state transitions. This PR fixes that.