### PR TITLE
Export rgb-core LIB_ID_RGB constant

### DIFF
--- a/std/src/stl/mod.rs
+++ b/std/src/stl/mod.rs
@@ -33,7 +33,9 @@ pub use specs::{
     Amount, AssetNaming, Attachment, BurnMeta, ContractData, Details, DivisibleAssetSpec,
     IssueMeta, Name, Precision, RicardianContract, Ticker, Timestamp,
 };
-pub use stl::{rgb_contract_stl, rgb_std_stl, StandardTypes, LIB_ID_RGB_CONTRACT, LIB_ID_RGB_STD};
+pub use stl::{
+    rgb_contract_stl, rgb_std_stl, StandardTypes, LIB_ID_RGB, LIB_ID_RGB_CONTRACT, LIB_ID_RGB_STD,
+};
 
 pub const LIB_NAME_RGB_CONTRACT: &str = "RGBContract";
 pub const LIB_NAME_RGB_STD: &str = "RGBStd";

--- a/std/src/stl/stl.rs
+++ b/std/src/stl/stl.rs
@@ -22,7 +22,7 @@
 use bp::bc::stl::bitcoin_stl;
 use bp::stl::bp_core_stl;
 use commit_verify::stl::commit_verify_stl;
-use rgb::stl::{aluvm_stl, rgb_core_stl};
+pub use rgb::stl::{aluvm_stl, rgb_core_stl, LIB_ID_RGB};
 use strict_types::stl::{std_stl, strict_types_stl};
 use strict_types::typesys::SystemBuilder;
 use strict_types::{CompileError, LibBuilder, SemId, SymbolicSys, TypeLib, TypeSystem};


### PR DESCRIPTION
I figured I'd just go ahead and make all the methods under stl/stl pub.